### PR TITLE
Ignore unknown location ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2025-12-08 -- v2.0.3
+### Fixed
+- Ignore unknown location ids
+
 ## 2025-12-04 -- v2.0.2
 ### Added
 - Collect system-wide alerts

--- a/lib/query_helper.py
+++ b/lib/query_helper.py
@@ -1,3 +1,5 @@
+_BRANCH_CODES_QUERY = "SELECT sierra_code FROM {redshift_table};"
+
 _LOCATION_HOURS_REDSHIFT_QUERY = """
     SELECT
         {redshift_table}.location_id,
@@ -13,6 +15,10 @@ _UPDATE_QUERY = """
     WHERE weekday = '{weekday}'
         AND location_id IN ({stale_locations_str})
         AND (date_of_change IS NULL OR date_of_change < '{today}');"""
+
+
+def build_branch_codes_query(redshift_table):
+    return _BRANCH_CODES_QUERY.format(redshift_table=redshift_table)
 
 
 def build_location_hours_redshift_query(redshift_table, weekday):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -279,7 +279,11 @@ class TestMain:
     def test_instance(self, mocker):
         mocker.patch("main.load_env_file")
         mocker.patch(
-            "main.build_location_hours_redshift_query", return_value="REDSHIFT QUERY"
+            "main.build_location_hours_redshift_query",
+            return_value="REDSHIFT HOURS QUERY",
+        )
+        mocker.patch(
+            "main.build_branch_codes_query", return_value="REDSHIFT BRANCH QUERY"
         )
 
     @pytest.fixture
@@ -323,6 +327,11 @@ class TestMain:
             main.main()
 
         assert caplog.text == ""
+        mock_redshift_client.connect.assert_called_once()
+        mock_redshift_client.execute_query.assert_called_once_with(
+            "REDSHIFT BRANCH QUERY"
+        )
+        mock_redshift_client.close_connection.assert_called_once()
         mock_avro_encoder.encode_batch.assert_called_once_with(_AVRO_ALERTS_INPUT)
         mock_kinesis_client.send_records.assert_called_once_with(
             [b"1", b"2", b"3", b"4"]
@@ -432,7 +441,9 @@ class TestMain:
         assert caplog.text == ""
         mock_locations_client.query.assert_called_once_with(False, "library")
         assert mock_redshift_client.connect.call_count == 2
-        mock_redshift_client.execute_query.assert_called_once_with("REDSHIFT QUERY")
+        mock_redshift_client.execute_query.assert_called_once_with(
+            "REDSHIFT HOURS QUERY"
+        )
         assert mock_redshift_client.close_connection.call_count == 2
         mock_update_builder.assert_called_once_with(
             "location_hours_v2_test_redshift_name",


### PR DESCRIPTION
Now that divisions and centers are included in the API response for alerts, full location closures include many ids: one for the location and one for each sublocation (e.g. reading rooms, teen centers, etc.). This makes aggregation difficult. Until we decide how such an aggregation should occur and how center/division closures should be determined, we will only track full location closures and only using a single id (the branch id).