### PR TITLE
Log unknown location ids as info

### DIFF
--- a/main.py
+++ b/main.py
@@ -192,9 +192,10 @@ def poll_location_closure_alerts(redshift_client, logger):
             if location_id is not None:
                 location_id = [l for l in location_id if l in known_locations]
             if alert["scope"] != "all" and not location_id:
-                logger.error(
+                logger.info(
                     f"No or unknown location id listed for alert {alert['id']} with "
-                    f"message: {alert['message_plain']}"
+                    f"location: {alert['location_codes']} and message: "
+                    f"{alert['message_plain']}"
                 )
                 continue
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -360,14 +360,6 @@ class TestMain:
         with caplog.at_level(logging.WARNING):
             main.main()
 
-        assert (
-            "No or unknown location id listed for alert 789 with message: no names"
-            in caplog.text
-        )
-        assert (
-            "No or unknown location id listed for alert 678 with message: unknown lib"
-            in caplog.text
-        )
         assert "NULL 'extended' value for alert 012" in caplog.text
         mock_avro_encoder.encode_batch.assert_called_once_with(
             [


### PR DESCRIPTION
This will prevent the poller from alarming when a center or division is closed.