### PR TITLE
Filter out names for unknown location ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2026-01-15 -- v2.1.0
+### Fixed
+- Filter out names corresponding to unknown location ids
+- Output one row per location id rather than concatenating the ids
+
 ## 2025-12-08 -- v2.0.3
 ### Fixed
 - Ignore unknown location ids

--- a/main.py
+++ b/main.py
@@ -172,7 +172,7 @@ def poll_location_closure_alerts(redshift_client, logger):
         build_branch_codes_query(redshift_table)
     )
     redshift_client.close_connection()
-    known_locations = {row[0] for row in raw_redshift_data}
+    all_known_locations = {row[0] for row in raw_redshift_data}
 
     # Query the API for every alert marked as a closure and construct a record
     # for each one
@@ -188,10 +188,32 @@ def poll_location_closure_alerts(redshift_client, logger):
             alert["closing_date_start"] is not None
             or alert["closing_date_end"] is not None
         ):
-            location_id = alert["location_codes"]
-            if location_id is not None:
-                location_id = [l for l in location_id if l in known_locations]
-            if alert["scope"] != "all" and not location_id:
+            raw_location_ids = (
+                [None] if alert["location_codes"] is None else alert["location_codes"]
+            )
+            raw_location_names = (
+                [None] if alert["location_names"] is None else alert["location_names"]
+            )
+            if len(raw_location_ids) != len(raw_location_names):
+                logger.error(
+                    "Differing numbers of location codes and names for alert "
+                    f"{alert['id']}: {alert['location_codes']} versus "
+                    f"{alert['location_names']}"
+                )
+                continue
+
+            # Filter out unknown locations -- usually centers/divisions -- which we
+            # choose not to track to avoid duplicate closures
+            known_location_ids = []
+            known_location_names = []
+            for i in range(len(raw_location_ids)):
+                loc_id = raw_location_ids[i]
+                if loc_id is None or loc_id in all_known_locations:
+                    known_location_ids.append(loc_id)
+                    known_location_names.append(raw_location_names[i])
+            if alert["scope"] != "all" and (
+                not known_location_ids or known_location_ids == [None]
+            ):
                 logger.info(
                     f"No or unknown location id listed for alert {alert['id']} with "
                     f"location: {alert['location_codes']} and message: "
@@ -204,39 +226,35 @@ def poll_location_closure_alerts(redshift_client, logger):
                 is_extended = None
             else:
                 is_extended = alert["extended"].lower() == "true"
-            records.append(
-                {
-                    "alert_id": alert["id"],
-                    "location_id": (
-                        None if location_id is None else ", ".join(location_id)
-                    ),
-                    "name": (
-                        None
-                        if alert["location_names"] is None
-                        else ", ".join(alert["location_names"])
-                    ),
-                    "closed_for": alert["message_plain"].strip(),
-                    "extended_closing": is_extended,
-                    "alert_start": (
-                        None
-                        if alert["closing_date_start"] is None
-                        else " ".join(alert["closing_date_start"].split("T"))
-                    ),
-                    "alert_end": (
-                        None
-                        if alert["closing_date_end"] is None
-                        else " ".join(alert["closing_date_end"].split("T"))
-                    ),
-                    "polling_datetime": polling_datetime,
-                }
-            )
+
+            for i in range(len(known_location_ids)):
+                records.append(
+                    {
+                        "alert_id": alert["id"],
+                        "location_id": known_location_ids[i],
+                        "name": known_location_names[i],
+                        "closed_for": alert["message_plain"].strip(),
+                        "extended_closing": is_extended,
+                        "alert_start": (
+                            None
+                            if alert["closing_date_start"] is None
+                            else " ".join(alert["closing_date_start"].split("T"))
+                        ),
+                        "alert_end": (
+                            None
+                            if alert["closing_date_end"] is None
+                            else " ".join(alert["closing_date_end"].split("T"))
+                        ),
+                        "polling_datetime": polling_datetime,
+                    }
+                )
 
     # If there are no alerts, still record the datetime of the polling, as it
     # may still be required by the LocationClosureAggregator
     if len(records) == 0:
         records.append(
             {
-                "drupal_location_id": "location_closure_alert_poller",
+                "location_id": "location_closure_alert_poller",
                 "polling_datetime": polling_datetime,
             }
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -117,22 +117,12 @@ _TEST_ALERTS_API_RESPONSE = [
     {
         "id": "789",
         "location_codes": ["libd", "fake"],
-        "location_names": ["library d", "library e"],
+        "location_names": ["library d", "library fake"],
         "message_plain": "extended closure",
         "extended": "true",
         "closing_date_start": "2022-12-31T00:00:00-05:00",
         "closing_date_end": "2023-02-31T00:00:00-05:00",
         "scope": "location",
-    },
-    {
-        "id": "012",
-        "location_codes": None,
-        "location_names": None,
-        "message_plain": "system closure",
-        "extended": "false",
-        "closing_date_start": "2023-01-01 00:00:00-05:00",
-        "closing_date_end": "2023-01-01 23:59:59-05:00",
-        "scope": "all",
     },
 ]
 
@@ -177,6 +167,16 @@ _TEST_ALERTS_API_WARNING_RESPONSE = [
         "closing_date_end": "2023-01-31T00:00:00-05:00",
         "scope": "location",
     },
+    {
+        "id": "910",
+        "location_codes": ["liba"],
+        "location_names": ["library a", "library b"],
+        "message_plain": "multiple names",
+        "extended": "false",
+        "closing_date_start": "2022-12-31T00:00:00-05:00",
+        "closing_date_end": "2023-01-31T00:00:00-05:00",
+        "scope": "location",
+    },
 ]
 
 _TEST_REDSHIFT_RESPONSE = [
@@ -212,8 +212,18 @@ _AVRO_ALERTS_INPUT = [
     },
     {
         "alert_id": "456",
-        "location_id": "libc, libcc",
-        "name": "library c, library cc",
+        "location_id": "libc",
+        "name": "library c",
+        "closed_for": "temporary closure 2",
+        "extended_closing": True,
+        "alert_start": "2022-12-31 00:00:00-05:00",
+        "alert_end": None,
+        "polling_datetime": "2023-01-01 01:23:45-05:00",
+    },
+    {
+        "alert_id": "456",
+        "location_id": "libcc",
+        "name": "library cc",
         "closed_for": "temporary closure 2",
         "extended_closing": True,
         "alert_start": "2022-12-31 00:00:00-05:00",
@@ -223,21 +233,11 @@ _AVRO_ALERTS_INPUT = [
     {
         "alert_id": "789",
         "location_id": "libd",
-        "name": "library d, library e",
+        "name": "library d",
         "closed_for": "extended closure",
         "extended_closing": True,
         "alert_start": "2022-12-31 00:00:00-05:00",
         "alert_end": "2023-02-31 00:00:00-05:00",
-        "polling_datetime": "2023-01-01 01:23:45-05:00",
-    },
-    {
-        "alert_id": "012",
-        "location_id": None,
-        "name": None,
-        "closed_for": "system closure",
-        "extended_closing": False,
-        "alert_start": "2023-01-01 00:00:00-05:00",
-        "alert_end": "2023-01-01 23:59:59-05:00",
         "polling_datetime": "2023-01-01 01:23:45-05:00",
     },
 ]
@@ -361,6 +361,9 @@ class TestMain:
             main.main()
 
         assert "NULL 'extended' value for alert 012" in caplog.text
+        assert (
+            "Differing numbers of location codes and names for alert 910" in caplog.text
+        )
         mock_avro_encoder.encode_batch.assert_called_once_with(
             [
                 {
@@ -402,7 +405,7 @@ class TestMain:
         mock_avro_encoder.encode_batch.assert_called_once_with(
             [
                 {
-                    "drupal_location_id": "location_closure_alert_poller",
+                    "location_id": "location_closure_alert_poller",
                     "polling_datetime": "2023-01-01 01:23:45-05:00",
                 }
             ]


### PR DESCRIPTION
This will allow us to 1) output one row per location id with the correct name, and 2) reduce the necessary size of the location id/name columns in the BIC